### PR TITLE
chore: Riverpod autoDispose handling

### DIFF
--- a/docs/PROJECT_GUIDELINES.md
+++ b/docs/PROJECT_GUIDELINES.md
@@ -44,6 +44,10 @@ Not every feature needs every file. Simple screens in the template only use `*_p
 - Stateful feature providers commonly use `@riverpod` classes ending in `StateNotifier`.
 - Shared notifier helpers live in `lib/core/riverpod/state_handler.dart`.
 - `AsyncValueExtension.mapState` and `mapContentState` from `lib/common/extension/async_value.dart` are the standard loading, error, and empty-state helpers.
+- Keep `@Riverpod(keepAlive: true)` for app-scoped state or long-lived services, not one-shot command providers.
+- For async use-case providers, prefer reading dependencies before the first `await` and continuing with captured objects instead of calling `ref` again later.
+- If an auto-dispose use-case truly must access `ref` after an async gap, keep it alive only for that operation with `final link = ref.keepAlive(); try { ... } finally { link.close(); }`.
+- If a page-scoped notifier resumes after `await`, guard UI-only follow-up work with `ref.mounted` before reading other providers or updating local state.
 
 ## One-Off Events
 - One-off UI events use `EventNotifier<T>` from `lib/core/riverpod/event_notifier.dart`.

--- a/lib/common/usecase/authentication/sign_out_use_case.dart
+++ b/lib/common/usecase/authentication/sign_out_use_case.dart
@@ -9,10 +9,11 @@ part 'sign_out_use_case.g.dart';
 
 @riverpod
 Future<void> signOutUseCase(Ref ref) async {
+  final currentUserStateNotifier = ref.read(currentUserStateProvider.notifier);
   Flogger.d('[Authentication] Going to sign out current user');
 
   // Title: Clear current user state
-  await ref.read(currentUserStateProvider.notifier).updateCurrentUser(null);
+  await currentUserStateNotifier.updateCurrentUser(null);
 
   // Title: Try to sign out from Google - if any
   try {


### PR DESCRIPTION
Added some notes about how the Riverpod's autodispose works.
Using `ref` after async `await ref.read` throws and error due to already disposed `ref`.
Added couple of scenarios how to handle this in our providers:

`@Riverpod(keepAlive: true)` for app-scoped state or long-lived services
- Read everything you need before the first await, then continue with captured objects
- Only if the provider truly must use ref again after an async gap, use pattern:
```
final link = ref.keepAlive();
try {
  ...
} finally {
  link.close();
}
```

- If the follow-up is only UI work, guard it with `ref.mounted` If the operation must finish even after leaving the screen, move that orchestration out of the page-scoped notifier